### PR TITLE
Add missing binary dependency to placeholder file

### DIFF
--- a/References/PLACEHOLDER.txt
+++ b/References/PLACEHOLDER.txt
@@ -1,5 +1,6 @@
 Copy here the proper version of these TFS assemblies:
 
+Microsoft.TeamFoundation.Client
 Microsoft.TeamFoundation.Common
 Microsoft.TeamFoundation.Framework.Server
 Microsoft.TeamFoundation.Git.Server


### PR DESCRIPTION
The placeholder file in the References directory only listed five of the
six required binary dependencies, though the complete list was available
in the readme file and has been copied here.
