### PR TITLE
Make robocopy use environment variable

### DIFF
--- a/GitPushFilter.csproj
+++ b/GitPushFilter.csproj
@@ -101,7 +101,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <PropertyGroup>
-    <PostBuildEvent>robocopy $(TargetDir) "\\vm-tfs2013\c$\Program Files\Microsoft Team Foundation Server 12.0\Application Tier\Web Services\bin\Plugins" $(TargetName).* /R:1 /W:0 /TBD
+    <PostBuildEvent>robocopy $(TargetDir) "$(TFS_HOME)\Application Tier\Web Services\bin\Plugins" $(TargetName).* /R:1 /W:0 /TBD
 REM IF %25ERRORLEVEL%25 GEQ 8 exit 1
 exit 0</PostBuildEvent>
   </PropertyGroup>

--- a/README.md
+++ b/README.md
@@ -81,3 +81,6 @@ To compile the project, you must copy in the `References` folder, the proper ver
  - Microsoft.VisualStudio.Services.WebApi
 
 Built and tested with Visual Studio 2013 Update 4 and TFS 2013 Update 4.
+
+You must define environment variable `TFS_HOME` to automatically copy the output to TFS plugin directory.
+For example, `%ProgramFiles%\Microsoft Team Foundation Server 12.0`


### PR DESCRIPTION
Fixed hard-coded network path "vm-tfs2013" to environment variable.
